### PR TITLE
Adding more synthetic data

### DIFF
--- a/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
@@ -38,7 +38,13 @@ class IAMOriginalAndSyntheticParagraphs(BaseDataModule):
 
         if stage == "fit" or stage is None:
             self.data_train = ConcatDataset([self.iam_paragraphs.data_train, self.iam_syn_paragraphs.data_train])
-            self.data_val = self.iam_paragraphs.data_val
+            self.data_val = ConcatDataset([self.iam_paragraphs.data_val, self.iam_syn_paragraphs.data_val])
+
+            print("\n\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+            print(f"Train:: number of samples: {len(self.data_train)}; number of batches: {len(self.data_train) / self.batch_size}; number of batches per GPU (8): {len(self.data_train) / (self.batch_size * 8)}")
+            print(f"Val:::: number of samples: {len(self.data_val)}; number of batches: {len(self.data_val) / self.batch_size}; number of batches per GPU (8): {len(self.data_val) / (self.batch_size * 8)}")
+            print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n")
+
         if stage == "test" or stage is None:
             self.data_test = self.iam_paragraphs.data_test
 


### PR DESCRIPTION
Changes in PR:
 - Using the IAM synthetic paragraphs validation dataset (along with the IAM paragraphs validation dataset) for validation
 - Generating a lot more synthetic paragraphs in `generate_synthetic_paragraphs()`


Wandb run - https://wandb.ai/fullstackdeeplearning/fsdl-text-recognizer-2022-training/runs/1w6b7fc9 
The run was unsuccessful (`validation loss` kept increasing after a few epochs) because of 1 bug: we didn't set `IAMSyntheticParagraphs.transform.scale_factor = 1` which was needed since we are using the IAM synthetic paragraphs validation dataset. So `IAMSyntheticParagraphs.transform.scale_factor` defaulted to 2.


Signed-off-by: srbhchandra <srbhchandra@gmail.com>