### PR TITLE
Attempting infinite train data

### DIFF
--- a/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
@@ -1,12 +1,11 @@
 """IAM Original and Synthetic Paragraphs Dataset class."""
 import argparse
 
-from torch.utils.data import ConcatDataset
+from torch.utils.data import ConcatDataset, DataLoader
 
 from text_recognizer.data.base_data_module import BaseDataModule, load_and_print_info
 from text_recognizer.data.iam_paragraphs import IAMParagraphs
 from text_recognizer.data.iam_synthetic_paragraphs import IAMSyntheticParagraphs
-from torch.utils.data import DataLoader
 
 
 class IAMOriginalAndSyntheticParagraphs(BaseDataModule):
@@ -39,22 +38,15 @@ class IAMOriginalAndSyntheticParagraphs(BaseDataModule):
 
         if stage == "fit" or stage is None:
             self.data_train = ConcatDataset([self.iam_paragraphs.data_train, self.iam_syn_paragraphs.data_train])
-            # self.data_val = ConcatDataset([self.iam_paragraphs.data_val, self.iam_syn_paragraphs.data_val])
             self.data_val = self.iam_paragraphs.data_val
-
-            print("\n\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
-            print(f"Train:: number of samples: {len(self.data_train)}; number of batches: {len(self.data_train) / self.batch_size}; number of batches per GPU (8): {len(self.data_train) / (self.batch_size * 8)}")
-            print(f"Val:::: number of samples: {len(self.data_val)}; number of batches: {len(self.data_val) / self.batch_size}; number of batches per GPU (8): {len(self.data_val) / (self.batch_size * 8)}")
-            print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n")
 
         if stage == "test" or stage is None:
             self.data_test = self.iam_paragraphs.data_test
 
     def train_dataloader(self):
-        # I can move synthetic data creation code here and set --reload_dataloaders_every_n_epochs in trainer.fit()
+        # Pair this synthetic data creation with --reload_dataloaders_every_n_epochs argument in trainer.fit()
         self.iam_syn_paragraphs.setup("train_only")
         self.data_train = ConcatDataset([self.iam_paragraphs.data_train, self.iam_syn_paragraphs.data_train])
-        print(f"Train:: number of samples: {len(self.data_train)}; number of batches: {len(self.data_train) / self.batch_size}; number of batches per GPU (8): {len(self.data_train) / (self.batch_size * 8)}")
         return DataLoader(
             self.data_train,
             shuffle=True,

--- a/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
@@ -38,7 +38,13 @@ class IAMOriginalAndSyntheticParagraphs(BaseDataModule):
 
         if stage == "fit" or stage is None:
             self.data_train = ConcatDataset([self.iam_paragraphs.data_train, self.iam_syn_paragraphs.data_train])
-            self.data_val = self.iam_paragraphs.data_val
+            self.data_val = ConcatDataset([self.iam_paragraphs.data_val, self.iam_syn_paragraphs.data_val])
+
+            print("\n\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
+            print(f"Train:: number of samples: {len(self.data_train)}; number of batches: {len(self.data_train) / self.batch_size}; number of batches per GPU (8): {len(self.data_train) / (self.batch_size * 8)}")
+            print(f"Val:::: number of samples: {len(self.data_val)}; number of batches: {len(self.data_val) / self.batch_size}; number of batches per GPU (8): {len(self.data_val) / (self.batch_size * 8)}")
+            print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&\n")
+
         if stage == "test" or stage is None:
             self.data_test = self.iam_paragraphs.data_test
 

--- a/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_original_and_synthetic_paragraphs.py
@@ -39,7 +39,8 @@ class IAMOriginalAndSyntheticParagraphs(BaseDataModule):
 
         if stage == "fit" or stage is None:
             self.data_train = ConcatDataset([self.iam_paragraphs.data_train, self.iam_syn_paragraphs.data_train])
-            self.data_val = ConcatDataset([self.iam_paragraphs.data_val, self.iam_syn_paragraphs.data_val])
+            # self.data_val = ConcatDataset([self.iam_paragraphs.data_val, self.iam_syn_paragraphs.data_val])
+            self.data_val = self.iam_paragraphs.data_val
 
             print("\n\n&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&")
             print(f"Train:: number of samples: {len(self.data_train)}; number of batches: {len(self.data_train) / self.batch_size}; number of batches per GPU (8): {len(self.data_train) / (self.batch_size * 8)}")
@@ -53,6 +54,7 @@ class IAMOriginalAndSyntheticParagraphs(BaseDataModule):
         # I can move synthetic data creation code here and set --reload_dataloaders_every_n_epochs in trainer.fit()
         self.iam_syn_paragraphs.setup("train_only")
         self.data_train = ConcatDataset([self.iam_paragraphs.data_train, self.iam_syn_paragraphs.data_train])
+        print(f"Train:: number of samples: {len(self.data_train)}; number of batches: {len(self.data_train) / self.batch_size}; number of batches per GPU (8): {len(self.data_train) / (self.batch_size * 8)}")
         return DataLoader(
             self.data_train,
             shuffle=True,

--- a/text_recognizer/data/iam_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_synthetic_paragraphs.py
@@ -30,6 +30,7 @@ class IAMSyntheticParagraphs(IAMParagraphs):
     def __init__(self, args: argparse.Namespace = None):
         super().__init__(args)
         self.trainval_transform.scale_factor = 1  # we perform rescaling ahead of time, in prepare_data
+        self.transform.scale_factor = 1  # we perform rescaling ahead of time, in prepare_data; not setting this was the problem
 
     def prepare_data(self, *args, **kwargs) -> None:
         """
@@ -63,11 +64,9 @@ class IAMSyntheticParagraphs(IAMParagraphs):
             Y = convert_strings_to_labels(strings=para_labels, mapping=self.inverse_mapping, length=self.output_dims[0])
             return BaseDataset(X, Y, transform=transform)
 
-        if stage == "fit" or stage is None:
+        if stage in ["fit", "train_only", None]:
             self.data_train = _load_dataset(split="train", transform=self.trainval_transform)
-            self.data_val = _load_dataset(split="val", transform=self.transform)
-        elif stage == "train_only":
-            self.data_train = _load_dataset(split="train", transform=self.trainval_transform)
+            # self.data_val = _load_dataset(split="val", transform=self.transform)
 
     def __repr__(self) -> str:
         """Print info about the dataset."""

--- a/text_recognizer/data/iam_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_synthetic_paragraphs.py
@@ -90,7 +90,12 @@ class IAMSyntheticParagraphs(IAMParagraphs):
 def generate_synthetic_paragraphs(
     line_crops: List[Image.Image], line_labels: List[str], max_batch_size: int = 12
 ) -> Tuple[List[Image.Image], List[str]]:
-    """Generate synthetic paragraphs and corresponding labels by randomly joining different subsets of crops."""
+    """
+    Generate synthetic paragraphs and corresponding labels by randomly joining different subsets of crops.
+    These synthetic paragraphs are generated such that the number of paragraphs with 1 line of text is greater
+    than the number of paragraphs with 2 lines of text is greater than the number of paragraphs with 3 lines of text
+    and so on.
+    """
     paragraph_properties = get_dataset_properties()
 
     indices = list(range(len(line_labels)))

--- a/text_recognizer/data/iam_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_synthetic_paragraphs.py
@@ -14,9 +14,9 @@ from text_recognizer.data.iam_paragraphs import (
     get_dataset_properties,
     IAMParagraphs,
 )
-from text_recognizer.stems.paragraph import ParagraphStem
 from text_recognizer.data.util import BaseDataset, convert_strings_to_labels, resize_image
 import text_recognizer.metadata.iam_synthetic_paragraphs as metadata
+from text_recognizer.stems.paragraph import ParagraphStem
 
 IMAGE_SCALE_FACTOR = metadata.IMAGE_SCALE_FACTOR
 NEW_LINE_TOKEN = metadata.NEW_LINE_TOKEN
@@ -30,7 +30,7 @@ class IAMSyntheticParagraphs(IAMParagraphs):
     def __init__(self, args: argparse.Namespace = None):
         super().__init__(args)
         self.trainval_transform.scale_factor = 1  # we perform rescaling ahead of time, in prepare_data
-        self.transform.scale_factor = 1  # we perform rescaling ahead of time, in prepare_data; not setting this was the problem
+        self.transform.scale_factor = 1
 
     def prepare_data(self, *args, **kwargs) -> None:
         """
@@ -46,7 +46,7 @@ class IAMSyntheticParagraphs(IAMParagraphs):
         iam = IAM()
         iam.prepare_data()
 
-        for split in ["train", "val"]:  # synthetic dataset is only used in training phase
+        for split in ["train"]:  # synthetic dataset is only used in training phase
             rank_zero_info(f"Cropping IAM line regions and loading labels for {split} data split...")
             crops, labels = line_crops_and_labels(iam, split)
 
@@ -66,7 +66,6 @@ class IAMSyntheticParagraphs(IAMParagraphs):
 
         if stage in ["fit", "train_only", None]:
             self.data_train = _load_dataset(split="train", transform=self.trainval_transform)
-            # self.data_val = _load_dataset(split="val", transform=self.transform)
 
     def __repr__(self) -> str:
         """Print info about the dataset."""
@@ -81,7 +80,7 @@ class IAMSyntheticParagraphs(IAMParagraphs):
 
         x, y = next(iter(self.train_dataloader()))
         data = (
-            f"Train/val/test sizes: {len(self.data_train)}, {len(self.data_val)}, 0\n"
+            f"Train/val/test sizes: {len(self.data_train)}, 0, 0\n"
             f"Train Batch x stats: {(x.shape, x.dtype, x.min(), x.mean(), x.std(), x.max())}\n"
             f"Train Batch y stats: {(y.shape, y.dtype, y.min(), y.max())}\n"
         )
@@ -111,10 +110,14 @@ def generate_synthetic_paragraphs(
         generate_random_batches(values=indices, min_batch_size=2, max_batch_size=max_batch_size)
     )
     batched_indices_list.extend(
-        generate_random_batches(values=indices, min_batch_size=(2 * max_batch_size) // 4 + 1, max_batch_size=max_batch_size)
+        generate_random_batches(
+            values=indices, min_batch_size=(2 * max_batch_size) // 4 + 1, max_batch_size=max_batch_size
+        )
     )
     batched_indices_list.extend(
-        generate_random_batches(values=indices, min_batch_size=(3 * max_batch_size) // 4 + 1, max_batch_size=max_batch_size)
+        generate_random_batches(
+            values=indices, min_batch_size=(3 * max_batch_size) // 4 + 1, max_batch_size=max_batch_size
+        )
     )
     # assert sorted(list(itertools.chain(*batched_indices_list))) == indices
 

--- a/text_recognizer/data/iam_synthetic_paragraphs.py
+++ b/text_recognizer/data/iam_synthetic_paragraphs.py
@@ -66,6 +66,8 @@ class IAMSyntheticParagraphs(IAMParagraphs):
         if stage == "fit" or stage is None:
             self.data_train = _load_dataset(split="train", transform=self.trainval_transform)
             self.data_val = _load_dataset(split="val", transform=self.transform)
+        elif stage == "train_only":
+            self.data_train = _load_dataset(split="train", transform=self.trainval_transform)
 
     def __repr__(self) -> str:
         """Print info about the dataset."""


### PR DESCRIPTION
Objective of this PR: recreate and use the synthetic train dataset on the fly during training.
This is achieved by recreating the `iam_syn_paragraphs.data_train` in `iam_original_and_synthetic_paragraphs.train_dataloader()` and instantiating the training using the command line arg `--reload_dataloaders_every_n_epochs=n`.

We set n to 40 in our experiments.

Wandb run - https://wandb.ai/fullstackdeeplearning/fsdl-text-recognizer-2022-training/runs/1u8h1c7k
We get our best metrics on `test` so far:
```
cer: 0.1250961422920227
loss: 0.7417508363723755
```
Wandb report - https://wandb.ai/fullstackdeeplearning/fsdl-text-recognizer-2022-training/reports/Report-for-misunderstood-galaxy-5--VmlldzoyMzgwODg5

### Misc

Past Wandb run - https://wandb.ai/fullstackdeeplearning/fsdl-text-recognizer-2022-training/runs/s9d2pgj4
This didn't train well (`validation loss` kept increasing after a few epochs) because of 1 bug: we didn't set `IAMSyntheticParagraphs.transform.scale_factor = 1` which was needed since we are using the IAM synthetic paragraphs validation dataset. So `IAMSyntheticParagraphs.transform.scale_factor` defaulted to 2.
We reverted to not using the IAM synthetic paragraphs validation dataset but also started setting `IAMSyntheticParagraphs.transform.scale_factor = 1`.

Signed-off-by: srbhchandra <srbhchandra@gmail.com>