### PR TITLE
added -nc (no clobber) to wget bootstrap in notebooks

### DIFF
--- a/notebooks/lab01_pytorch.ipynb
+++ b/notebooks/lab01_pytorch.ipynb
@@ -102,7 +102,7 @@
         "        !echo $PYTHONPATH\n",
         "\n",
         "    # get both Colab and local notebooks into the same state\n",
-        "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+        "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
         "    import bootstrap\n",
         "\n",
         "    # change into the lab directory\n",

--- a/notebooks/lab02a_lightning.ipynb
+++ b/notebooks/lab02a_lightning.ipynb
@@ -71,7 +71,7 @@
         "        !echo $PYTHONPATH\n",
         "\n",
         "    # get both Colab and local notebooks into the same state\n",
-        "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+        "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
         "    import bootstrap\n",
         "\n",
         "    # change into the lab directory\n",

--- a/notebooks/lab02b_cnn.ipynb
+++ b/notebooks/lab02b_cnn.ipynb
@@ -70,7 +70,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab03_transformers.ipynb
+++ b/notebooks/lab03_transformers.ipynb
@@ -73,7 +73,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab04_experiments.ipynb
+++ b/notebooks/lab04_experiments.ipynb
@@ -71,7 +71,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab05_troubleshooting.ipynb
+++ b/notebooks/lab05_troubleshooting.ipynb
@@ -71,7 +71,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab06_data.ipynb
+++ b/notebooks/lab06_data.ipynb
@@ -72,7 +72,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab07_deployment.ipynb
+++ b/notebooks/lab07_deployment.ipynb
@@ -56,7 +56,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab08_monitoring.ipynb
+++ b/notebooks/lab08_monitoring.ipynb
@@ -49,7 +49,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "    \n",
     "    %matplotlib inline\n",

--- a/notebooks/lab99_iam_arcana.ipynb
+++ b/notebooks/lab99_iam_arcana.ipynb
@@ -64,7 +64,7 @@
     "        !echo $PYTHONPATH\n",
     "\n",
     "    # get both Colab and local notebooks into the same state\n",
-    "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+    "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
     "    import bootstrap\n",
     "\n",
     "    # change into the lab directory\n",

--- a/notebooks/lab99_template.ipynb
+++ b/notebooks/lab99_template.ipynb
@@ -92,7 +92,7 @@
         "        !echo $PYTHONPATH\n",
         "\n",
         "    # get both Colab and local notebooks into the same state\n",
-        "    !wget --quiet https://fsdl.me/gist-bootstrap -O bootstrap.py\n",
+        "    !wget --quiet https://fsdl.me/gist-bootstrap -nc -O bootstrap.py\n",
         "    import bootstrap\n",
         "\n",
         "    # change into the lab directory\n",


### PR DESCRIPTION
this flag will skip bootstrap.py files if they already exist, I noticed it would be annoying to run when I have no internet because wget will time out and delete the already existing bootstrap.py files, `-nc` will simply skip the download and network call if the file already exists